### PR TITLE
Update RealSystemFacade.java

### DIFF
--- a/src/com/mozillaonline/providers/downloads/RealSystemFacade.java
+++ b/src/com/mozillaonline/providers/downloads/RealSystemFacade.java
@@ -14,7 +14,7 @@ class RealSystemFacade implements SystemFacade {
     private Context mContext;
     private NotificationManager mNotificationManager;
     // 2 GB
-    private static final long DOWNLOAD_MAX_BYTES_OVER_MOBILE = 2 * 1024 * 1024 * 1024;
+    private static final long DOWNLOAD_MAX_BYTES_OVER_MOBILE = 2 * 1024 * 1024 * 1024L;
     // 1 GB
     private static final long DOWNLOAD_RECOMMENDED_MAX_BYTES_OVER_MOBILE = 1024 * 1024 * 1024;
     public RealSystemFacade(Context context) {


### PR DESCRIPTION
fix bug: getMaxBytesOverMobile() will return a negative value at runtime.
change DOWNLOAD_MAX_BYTES_OVER_MOBILE, add 'L' at the end. 
(Android Studio 0.5.8 with Android SDK Build-tools 19.1 on Mac OSX 10.9.3)
